### PR TITLE
feat(maxWidth): set default max width for uploaded images

### DIFF
--- a/src/PluginSettings.ts
+++ b/src/PluginSettings.ts
@@ -2,4 +2,5 @@ export class PluginSettings {
   public attachmentLinksDelimiter = '\n\n';
   public attachmentLinksPrefix = '';
   public attachmentLinksSuffix = '';
+  public attachmentMaxWidth = '';
 }

--- a/src/PluginSettingsTab.ts
+++ b/src/PluginSettingsTab.ts
@@ -50,6 +50,19 @@ export class PluginSettingsTab extends PluginSettingsTabBase<PluginTypes> {
 
         handleWhitespace(text);
       });
+
+    new Setting(this.containerEl)
+      .setName('Attachment max Width')
+      .setDesc('The maximum width for inserted image attachments')
+      .addText((text) => {
+        text.inputEl.type = 'number';
+        this.bind(text, 'attachmentMaxWidth', {
+          componentToPluginSettingsValueConverter: restoreWhitespaceCharacters,
+          pluginSettingsToComponentValueConverter: showWhitespaceCharacters
+        });
+
+        handleWhitespace(text);
+      });
   }
 }
 


### PR DESCRIPTION
- Apply maxWidth setting to uploaded images
- Preserve image aspect ratio when resizing
- Compatible with image converter 'drag or scroll to resize'

<img width="786" height="279" alt="image" src="https://github.com/user-attachments/assets/4056d323-fb74-4447-bc6e-f6be8eac567a" />

<img width="301" height="327" alt="image" src="https://github.com/user-attachments/assets/df54237b-434e-4cc3-b850-3cbae2e0d9cc" />
